### PR TITLE
Add support for symbol emphasis

### DIFF
--- a/syntaxes/notes.tmLanguage.json
+++ b/syntaxes/notes.tmLanguage.json
@@ -103,7 +103,7 @@
     {
       "comment": "Emphasis",
       "name": "keyword.other.notes",
-      "match": "(\\*+[a-zA-Z \\t]+\\*+)"
+      "match": "(\\*+.*?\\*+)"
     },
     {
       "comment": "Arrows",


### PR DESCRIPTION
Fix for issue #5 

Adding support for highlighting emphasized phrases such as
\*123\*
\*-/$%@~\*